### PR TITLE
Fix: EventEmitter namespace/class import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@social-native/snpkg-snapi-kafka-sagas",
-    "version": "4.1.0",
+    "version": "4.3.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@social-native/snpkg-snapi-kafka-sagas",
-    "version": "4.3.3",
+    "version": "4.3.4",
     "description": "",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",

--- a/src/topic_event_emitter.ts
+++ b/src/topic_event_emitter.ts
@@ -1,6 +1,6 @@
 import {Kafka, Consumer} from 'kafkajs';
 import uuid from 'uuid';
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 
 export class TopicEventEmitter {
     public emitter: EventEmitter = new EventEmitter();


### PR DESCRIPTION
Importing `EventEmitter` instead of `{EventEmitter}` gives you a namespace AND a class.