### PR TITLE
Fix heartbeat unhandledRejection, use transactionId as key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-sagas",
-    "version": "13.0.0",
+    "version": "13.1.0",
     "description": "Build sagas that consume from a kafka topic",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",

--- a/src/__tests__/create_action_message.test.ts
+++ b/src/__tests__/create_action_message.test.ts
@@ -20,6 +20,7 @@ describe(createActionMessage.name, function() {
               "headers": Object {
                 "key": "value",
               },
+              "key": "test-transaction-id",
               "value": "{\\"transaction_id\\":\\"test-transaction-id\\",\\"payload\\":{\\"persimmon\\":\\"yum\\"}}",
             }
         `);

--- a/src/create_action_message.ts
+++ b/src/create_action_message.ts
@@ -2,13 +2,12 @@ import {Message} from 'kafkajs';
 import {IAction} from './types';
 
 export function createActionMessage<Action extends IAction>({action}: {action: Action}): Message {
-    const message = {
+    return {
+        key: action.transaction_id,
         value: JSON.stringify({
             transaction_id: action.transaction_id,
             payload: action.payload
         }),
         headers: action.headers
     };
-
-    return message;
 }

--- a/src/topic_saga_consumer.ts
+++ b/src/topic_saga_consumer.ts
@@ -227,10 +227,8 @@ export class TopicSagaConsumer<Payload, Context extends Record<string, any> = Re
 
     public async disconnect() {
         await this.consumer.disconnect();
-        await Bluebird.all([
-            this.consumerPool.disconnectConsumers(),
-            this.throttledProducer.disconnect()
-        ]);
+        await this.consumerPool.disconnectConsumers();
+        await this.throttledProducer.disconnect();
     }
 
     private eachMessage = async (

--- a/src/topic_saga_consumer.ts
+++ b/src/topic_saga_consumer.ts
@@ -184,7 +184,13 @@ export class TopicSagaConsumer<Payload, Context extends Record<string, any> = Re
                 isRunning,
                 isStale
             }) => {
-                const backgroundHeartbeat = setInterval(heartbeat, this.config.heartbeatInterval);
+                const backgroundHeartbeat = setInterval(async () => {
+                    try {
+                        await heartbeat();
+                    } catch (error) {
+                        this.logger.error(error, error.message);
+                    }
+                }, this.config.heartbeatInterval);
 
                 for (const message of messages) {
                     if (!isRunning() || isStale()) {


### PR DESCRIPTION
1. Heartbeat errors should log instead of being uncaught rejections.
2. All messages within a transaction will end up assigned to the same partition, ensuring order is retained.