### PR TITLE
Don't continue failing heartbeats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-sagas",
-    "version": "14.0.0",
+    "version": "14.0.1",
     "description": "Build sagas that consume from a kafka topic",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",

--- a/src/topic_saga_consumer.ts
+++ b/src/topic_saga_consumer.ts
@@ -231,6 +231,11 @@ export class TopicSagaConsumer<Payload, Context extends Record<string, any> = Re
 
                         await heartbeat();
                     } catch (e) {
+                        if (this.backgroundHeartbeat) {
+                            clearInterval(this.backgroundHeartbeat);
+                            this.backgroundHeartbeat = undefined;
+                        }
+
                         await commitOffsetsIfNecessary();
                         throw e;
                     }
@@ -242,9 +247,8 @@ export class TopicSagaConsumer<Payload, Context extends Record<string, any> = Re
 
                 if (this.backgroundHeartbeat) {
                     clearInterval(this.backgroundHeartbeat);
+                    this.backgroundHeartbeat = undefined;
                 }
-
-                this.backgroundHeartbeat = undefined;
             }
         });
     }
@@ -252,6 +256,7 @@ export class TopicSagaConsumer<Payload, Context extends Record<string, any> = Re
     public async disconnect() {
         if (this.backgroundHeartbeat) {
             clearInterval(this.backgroundHeartbeat);
+            this.backgroundHeartbeat = undefined;
         }
 
         await this.consumer.disconnect();


### PR DESCRIPTION
- Ensure a heartbeat before and after message consumption
- De-queue async heartbeats if one failed
- Clear background heartbeater after message consumption batch so they don't continue forever