### PR TITLE
Add a config for using transaction_id as key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kafka-sagas",
-    "version": "17.0.0",
+    "version": "17.1.0",
     "description": "Build sagas that consume from a kafka topic",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",

--- a/src/throttled_producer.ts
+++ b/src/throttled_producer.ts
@@ -31,12 +31,28 @@ export class ThrottledProducer {
     }
 
     // tslint:disable-next-line: cyclomatic-complexity
-    public putAction = async <Action extends IAction>(action: Action) => {
+    public putAction = async <Action extends IAction>(
+        action: Action,
+        messageConfig: {
+            /**
+             * If using transactionId as a message key, messages in a transaction will be processed in order.
+             */
+            useTransactionIdAsKey?: boolean;
+        } = {
+            useTransactionIdAsKey: false
+        }
+    ) => {
         if (!this.isConnected) {
             throw new Error('You must .connect before producing actions');
         }
 
         return new Promise<void>((resolve, reject) => {
+            const message = createActionMessage({action});
+
+            if (messageConfig.useTransactionIdAsKey) {
+                message.key = action.transaction_id;
+            }
+
             this.recordQueue = [
                 ...this.recordQueue,
                 {


### PR DESCRIPTION
This is useful when you *do* want transaction events to be processed sequentially, for instance, when publishing the current status of a transaction.

This way the following example actually gets consumed in the order it was produced:
```ts
put(STARTED);
put(COMPLETED);
```